### PR TITLE
Fix for LibSass error compiling keyframe @mixin

### DIFF
--- a/helpers/_mixins.scss
+++ b/helpers/_mixins.scss
@@ -32,19 +32,19 @@
 // Courtesy of @integralist: (twitter.com)                       //
 //===============================================================//
 @mixin keyframe ($animation-name) {
-    @-webkit-keyframes $animation-name{
+    @-webkit-keyframes #{$animation-name}{
         @content;
     }
 
-    @-moz-keyframes $animation-name{
+    @-moz-keyframes #{$animation-name}{
         @content;
     }
 
-    @-o-keyframes $animation-name{
+    @-o-keyframes #{$animation-name}{
         @content;
     }
 
-    @keyframes $animation-name{
+    @keyframes #{$animation-name}{
         @content;
     }
 }


### PR DESCRIPTION
Hey Tom, great handy library!  Was just using this with node / libsass compiler and hit upon an error, fix is included which should work with all compilers.

Error:

```
Warning: bower_components/animate-sass/helpers/mixins:35: error: non-terminal statement or declaration must end with ';'
 Use --force to continue.

Aborted due to warnings.
```

More information here : https://github.com/sindresorhus/grunt-sass/issues/33#issuecomment-34324000
