### PR TITLE
Updated main file name in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Tom Gillard <tomgillar@gmail.com>"
   ],
   "description": "A Sass library of Dan Eden's Animate.css",
-  "main": "animate.scss",
+  "main": "_animate.scss",
   "keywords": [
     "animate-sass",
     "animate.css",


### PR DESCRIPTION
The missing underscore in the main reference file was causing Sprockets precompile to fail.
