### PR TITLE
Use CSS calc() instead of Sass multiplication to allow $base-duration to be set as CSS custom property

### DIFF
--- a/helpers/_base.scss
+++ b/helpers/_base.scss
@@ -10,7 +10,7 @@ body {
 }
 
 .animated {
-  	@include animate-prefixer(animation-duration, $base-duration);
+  	@include animate-prefixer(animation-duration, calc( #{$base-duration} ) );
   	@include animate-prefixer(animation-fill-mode, $base-fill-mode);
 
 	&.infinite {
@@ -18,16 +18,16 @@ body {
 	}
 
 	&.hinge {
-	  @include animate-prefixer(animation-duration, $base-duration * 2);
+	  @include animate-prefixer(animation-duration, calc( #{$base-duration} * 2 ) );
 	}
 
 	&.bounceIn,
 	&.bounceOut {
-	  @include animate-prefixer(animation-duration, $base-duration * 0.75);
+	  @include animate-prefixer(animation-duration, calc( #{$base-duration} * 0.75 ) );
 	}
 
 	&.flipOutX,
 	&.flipOutY {
-	  @include animate-prefixer(animation-duration, $base-duration * 0.75);
+	  @include animate-prefixer(animation-duration, calc( #{$base-duration} * 0.75 ) );
 	}
 }


### PR DESCRIPTION
Modifies `_base.scss`  so that we can set the base-duration using a CSS custom property (e.g, so that the duration can be referenced in JS.